### PR TITLE
Fixes for Cygwin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.php   text
+*.json  text
+*.sh    eol=lf
+*.bat   eol=crlf

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Currently implemented:
  - clean (removes all dead symlinks)
  - create (creates a modman file for an existing module)
  - clone (clones a git repository)
+ - remove <target> (removes the symlinks)
 
 
---force is available for link, deploy, deploy-all and clone, if not set script aborts when conflicts are found
+--force is available for link, deploy, deploy-all, remove and clone, if not set script aborts when conflicts are found
 
 Usage examples:
 

--- a/modman.sh
+++ b/modman.sh
@@ -14,10 +14,13 @@
 #
 function setupEnv() {
     shopt -s nocasematch
-    if [[ `uname -a` =~ cygwin ]]
+    if [[ `cmd /c ver` =~ Version\ *[6789] ]]
     then
-        CYGWIN=`echo "$CYGWIN" | sed -e 's/winsymlinks[:a-z]*//' -e 's/$/ winsymlinks:native/'`
-        export CYGWIN
+        if [[ `uname -a` =~ cygwin ]]
+        then
+            CYGWIN=`echo "$CYGWIN" | sed -e 's/winsymlinks[:a-z]*//' -e 's/$/ winsymlinks:native/'`
+            export CYGWIN
+        fi
     fi
 }
 

--- a/modman.sh
+++ b/modman.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
 
+#
+# If running under Cygwin, set the type of symlinks we want to use.
+# For modman-php we want native NTFS symbolic links.  Windows shortcuts
+# and Cygwin default symbolic links are not seen by Git or PhpStorm
+# and therefore renders modman-php useless in these cases.
+#
+# Using winsymlinks:native works for me, but according to this thread:
+#  http:#stackoverflow.com/questions/19780951/cygwin-winsymlinksnative-doesnt-work
+# some people may experience problems. Perhaps there are version issues.
+# To cover all cases more investigation and additional logic may be needed.
+# RJR 9-Apr-15
+#
+function setupEnv() {
+    shopt -s nocasematch
+    if [[ `uname -a` =~ cygwin ]]
+    then
+        CYGWIN=`echo "$CYGWIN" | sed -e 's/winsymlinks[:a-z]*//' -e 's/$/ winsymlinks:native/'`
+        export CYGWIN
+    fi
+}
+
+setupEnv
 sScript="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/modman.php";
 php "$sScript" "$@"; 


### PR DESCRIPTION
I use Cygwin on Windows 7 and found that the default symlinks don't allow Git or Phpstorm to work properly with modman'd projects.

The problem is resolved by setting 'winsymlinks:native' in the CYGWIN environment variable.

Apparently, command line PHP on Cygwin uses this variable for its "symlink" and related functions.

My fork fixes a number of things, but this is the main item.