### PR TITLE
Implement cross platform solution for deleting directory symlinks

### DIFF
--- a/modman.php
+++ b/modman.php
@@ -1171,8 +1171,9 @@ class Modman_Resource_Remover{
 			if (is_link($sElementPath) OR $this->isFolderEmpty($sElementPath)){
 				// workaround for windows to delete read-only flag
 				// which prevents link from being deleted properly
-                chmod($sElementPath, 0777);
-                rmdir($sElementPath);
+				chmod($sElementPath, 0777);
+				// directory symlinks must be deleted with rmdir on windows
+				@unlink($sElementPath) or rmdir($sElementPath);
 			}
         } elseif (is_file($sElementPath)){
 			// workaround for windows to delete read-only flag


### PR DESCRIPTION
As  @tomlankhorst mentioned in #31, symlinks usually should be `unlink`ed, but directory symlinks *on Windows* need to be `rmdir`d.

To satisfy all platforms, we always try `unlink()` first, followed by `rmdir()` if it did not work.