### PR TITLE
Fix stricts error

### DIFF
--- a/modman.php
+++ b/modman.php
@@ -293,7 +293,7 @@ class Modman_Command_Link_Line {
         $sBaseDirFile = Modman_Command_Init::getBaseDirFile();
         if (file_exists($sBaseDirFile)) {
             $filecontent = file($sBaseDirFile, FILE_IGNORE_NEW_LINES);
-            $sBaseDir = rtrim(array_shift($fileContent);
+            $sBaseDir = rtrim(array_shift($fileContent));
         }
         return $sBaseDir . DIRECTORY_SEPARATOR . $this->rtrimDS($this->sSymlink);
     }

--- a/modman.php
+++ b/modman.php
@@ -292,7 +292,7 @@ class Modman_Command_Link_Line {
         $sBaseDir = getcwd();
         $sBaseDirFile = Modman_Command_Init::getBaseDirFile();
         if (file_exists($sBaseDirFile)) {
-            $filecontent = file($sBaseDirFile, FILE_IGNORE_NEW_LINES);
+            $fileContent = file($sBaseDirFile, FILE_IGNORE_NEW_LINES);
             $sBaseDir = rtrim(array_shift($fileContent));
         }
         return $sBaseDir . DIRECTORY_SEPARATOR . $this->rtrimDS($this->sSymlink);

--- a/modman.php
+++ b/modman.php
@@ -143,6 +143,10 @@ EOH;
         echo $sHelp . PHP_EOL;
     }
 
+    function __call($name, $arguments)
+    {
+        // TODO: Implement __call() method.
+    }
 }
 
 class Modman_Command_All {
@@ -288,7 +292,7 @@ class Modman_Command_Link_Line {
         $sBaseDir = getcwd();
         $sBaseDirFile = Modman_Command_Init::getBaseDirFile();
         if (file_exists($sBaseDirFile)) {
-            $filecontent = file($sBaseDirFile, FILE_IGNORE_NEW_LINES));
+            $filecontent = file($sBaseDirFile, FILE_IGNORE_NEW_LINES);
             $sBaseDir = rtrim(array_shift($fileContent);
         }
         return $sBaseDir . DIRECTORY_SEPARATOR . $this->rtrimDS($this->sSymlink);

--- a/modman.php
+++ b/modman.php
@@ -288,7 +288,8 @@ class Modman_Command_Link_Line {
         $sBaseDir = getcwd();
         $sBaseDirFile = Modman_Command_Init::getBaseDirFile();
         if (file_exists($sBaseDirFile)) {
-            $sBaseDir = rtrim(array_shift(file($sBaseDirFile, FILE_IGNORE_NEW_LINES)));
+            $filecontent = file($sBaseDirFile, FILE_IGNORE_NEW_LINES));
+            $sBaseDir = rtrim(array_shift($fileContent);
         }
         return $sBaseDir . DIRECTORY_SEPARATOR . $this->rtrimDS($this->sSymlink);
     }


### PR DESCRIPTION
This fixes #41 by assigning the return value of `file()` to a variable before passing it to `array_shift()`
